### PR TITLE
A few fixes to the example in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,6 @@ fn handle_some_requests(req: &mut Request) {
   // clients can't tamper with foo- it's signed when set and verified when loaded.
   // invalid signatures are equivalent to the cookie not existing.
   let mut resp = Response::new();
-  resp.set_cookie(Cookie::new("foo", "new and interesting value of foo!"));
-  
+  resp.set_cookie(cookie::Cookie::new("foo", "new and interesting value of foo!"));
+}
+```


### PR DESCRIPTION
Cookie isn't correctly namespaced in the example (but it is correct in the comment).

Also I added the closing curly brace because I'm a pedantic jerk.
