### PR TITLE
Updated dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,12 @@
 [package]
 name = "oven"
-version = "0.4.0"
+version = "1.0.0"
 authors = ["XMPPwocky <nttheis@gmail.com>", "Markus Kohlhase <mail@markus-kohlhase.de>"]
 repository = "https://github.com/flosse/oven"
 description = "Simple cookie management for Iron"
 license = "MIT"
 
 [dependencies]
+hyper = "^0.9.10"
 iron = "^0.4.0"
 plugin = "^0.2.6"
-
-[dependencies.cookie]
-version = "^0.2.2"
-features = ["secure"]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ simple cookie middleware for Iron
 extern crate hyper;
 extern crate oven;
 
-use hyper::header::CookiePair;
+use iron::headers::CookiePair;
 use oven::prelude::*;
 
 fn initialize_my_webapp_pls() {

--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@ simple cookie middleware for Iron
 
 ```rust
 
-extern crate cookie;
+extern crate hyper;
 extern crate oven;
 
+use hyper::header::CookiePair;
 use oven::prelude::*;
 
 fn initialize_my_webapp_pls() {
@@ -14,10 +15,10 @@ fn initialize_my_webapp_pls() {
 }
 
 fn handle_some_requests(req: &mut Request) {
-  let foocookie = req.get_cookie("foo"); // foo = Option<cookie::Cookie>
+  let foocookie = req.get_cookie("foo"); // foo = Option<&CookiePair>
   // clients can't tamper with foo- it's signed when set and verified when loaded.
   // invalid signatures are equivalent to the cookie not existing.
   let mut resp = Response::new();
-  resp.set_cookie(cookie::Cookie::new("foo", "new and interesting value of foo!"));
+  resp.set_cookie("foo", "new and interesting value of foo!");
 }
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,14 +36,13 @@ pub mod prelude {
 
 pub trait ResponseExt {
     /// Extension method to simplify setting cookies.
-    fn set_cookie(&mut self, name: &str, value: &str);
+    fn set_cookie(&mut self, cookie: CookiePair);
 }
 
 impl ResponseExt for Response {
-    fn set_cookie(&mut self, name: &str, value: &str) {
+    fn set_cookie(&mut self, cookie: CookiePair) {
         // FIXME: what if there's already a cookie by this name?
-        let cookie = CookiePair::new(name.to_owned(), value.to_owned());
-        self.get_mut::<ResponseCookies>().unwrap().insert(name.to_string(), cookie);
+        self.get_mut::<ResponseCookies>().unwrap().insert(cookie.name.to_string(), cookie);
     }
 }
 


### PR DESCRIPTION
Hyper absorbed Cookie in v0.9.10. This commit reflects this change by replacing the cookie dependency by an explicit hyper dependency (though hyper is already required by iron).

Prototypes for get_cookie and set_cookie were updated accordingly. Because this is a breaking change, I bumped the major version number. If this project doesn't follow semantic versioning, we can name this 0.5.0 instead.
